### PR TITLE
Assert that OpenGL function pointers are loaded

### DIFF
--- a/src/gl_back_end.rs
+++ b/src/gl_back_end.rs
@@ -295,6 +295,13 @@ impl Textured {
     }
 }
 
+// Newlines and indents for cleaner panic message.
+const GL_FUNC_NOT_LOADED: &'static str = "
+    OpenGL function pointers must be loaded before creating the `Gl` backend!
+    For more info, see the following issue on GitHub:
+    https://github.com/PistonDevelopers/opengl_graphics/issues/103
+";
+
 /// Contains OpenGL data.
 pub struct Gl {
     colored: Colored,
@@ -304,10 +311,15 @@ pub struct Gl {
     color: [f32, ..4],
 }
 
-
 impl<'a> Gl {
-    /// Creates a new OpenGl back-end.
+    /// Creates a new OpenGL back-end.
+    ///
+    /// # Panics
+    /// If the OpenGL function pointers have not been loaded yet.  
+    /// See https://github.com/PistonDevelopers/opengl_graphics/issues/103 for more info.
     pub fn new(opengl: opengl::OpenGL) -> Gl {
+        assert!(gl::Enable::is_loaded(), GL_FUNC_NOT_LOADED);
+
         let glsl = opengl.to_GLSL();
         // Load the vertices, color and texture coord buffers.
         Gl {
@@ -464,3 +476,9 @@ impl BackEnd<Texture> for Gl {
     }
 }
 
+// Might not fail if previous tests loaded functions.
+#[test]
+#[should_fail]
+fn test_gl_loaded() {
+    Gl::new(opengl::OpenGL::_3_2);
+}


### PR DESCRIPTION
Closes #59.

Coincidentally, this _should_ cover the case where OpenGL was improperly loaded and the software fallback was returned, since the fallback is often the pre-2.0 fixed pipeline and will have none of the functions that should have actually been loaded. According to the specs, `glEnable` should be available in OpenGL >= 2.0 but not prior to that.

I went the little extra mile to make sure the panic message looks nice in a terminal, including some newlines and whitespace to make it easily readable, and kept the lines under 80 columns:

```
task '<main>' panicked at '
    OpenGL function pointers must be loaded before creating the `Gl` backend!
    For more info, see the following issue on GitHub:
    https://github.com/PistonDevelopers/opengl_graphics/issues/103
', src/gl_back_end.rs:322
```

Gnome-Terminal hotlinks the URL to #103, which is really neat. Otherwise it's pretty easily copyable.

The unit test I included is a little superfluous, it just makes sure the assert hits when the functions aren't loaded. I can remove it if need be. It kind of seems out of place, since so many Piston repos forego any kind of unit testing.

I have tested this with `sdl2_window`, and the assert passes.
