### PR TITLE
Upgraded to latest Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-opengl_graphics"
-version = "0.0.4"
+version = "0.0.5"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,18 @@
 //! Errors
 
+use std::fmt;
+
 /// An enum to represent various possible run-time errors that may occur.
 #[derive(Copy, Show, PartialEq, Eq)]
 pub enum Error {
     /// An error happened with the FreeType library.
     FreetypeError(::freetype::error::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::fmt::Show;
+
+        self.fmt(f)
+    }
 }


### PR DESCRIPTION
* Implemented `Display` for `Error` because it is needed for `.unwrap`