### PR TITLE
Fix integer type from ffi::FT_ULong to usize

### DIFF
--- a/src/glyph_cache.rs
+++ b/src/glyph_cache.rs
@@ -2,7 +2,6 @@
 //! Glyph caching
 
 use error::Error;
-use freetype::ffi;
 use freetype;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
@@ -49,7 +48,7 @@ impl GlyphCache {
             .unwrap_or(false) { return; }
 
         self.face.set_pixel_sizes(0, size).unwrap();
-        self.face.load_char(ch as ffi::FT_ULong, freetype::face::DEFAULT).unwrap();
+        self.face.load_char(ch as usize, freetype::face::DEFAULT).unwrap();
         let glyph = self.face.glyph().get_glyph().unwrap();
         let bitmap_glyph = glyph.to_bitmap(freetype::render_mode::RenderMode::Normal, None)
             .unwrap();


### PR DESCRIPTION
Provides compatiblity with [latest freetype](https://github.com/PistonDevelopers/freetype-rs/commit/8c548000474ba0e770631f7b265058e19d91f28d).

Issue was introduced with: freetype-rs [PR #111](https://github.com/PistonDevelopers/freetype-rs/pull/111) on [this](https://github.com/PistonDevelopers/freetype-rs/commit/e4ced6f235b6deba0f2aa1cf5939efe662a3b44b#diff-0c08c84b5c931423f9906098268d1a8cL122) line.