### PR TITLE
CString object must live for as long as its pointer

### DIFF
--- a/src/shader_utils.rs
+++ b/src/shader_utils.rs
@@ -173,9 +173,9 @@ pub fn attribute_location(program: GLuint, name: &str) -> Result<GLuint, String>
     unsafe {
         let id = gl::GetAttribLocation(program, 
             match CString::new(name.as_bytes()) {
-                Ok(x) => x.as_ptr(),
+                Ok(x) => x,
                 Err(err) => { return Err(format!("attribute_location: {}", err)); }
-            });
+            }.as_ptr());
         if id < 0 { 
             Err(format!("Attribute '{}' does not exists in shader", name))
         } else {


### PR DESCRIPTION
Fixes a use-after-free bug.