### PR TITLE
Implemented `texture::Rgba8Texture` for `Texture`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-opengl_graphics"
-version = "0.11.1"
+version = "0.12.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,12 @@ extern crate gl;
 extern crate libc;
 extern crate graphics;
 extern crate freetype;
+extern crate texture as texture_lib;
 
 pub use shader_version::OpenGL;
 pub use back_end::GlGraphics;
 pub use texture::Texture;
+pub use texture_lib::*;
 
 pub mod shader_utils;
 pub mod glyph_cache;


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/opengl_graphics/issues/199

* Reexported `piston-texture` at top level
* Bumped to 0.12.0