### PR TITLE
Draw state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-opengl_graphics"
-version = "0.14.0"
+version = "0.14.1"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/examples/draw_state.rs
+++ b/examples/draw_state.rs
@@ -1,0 +1,81 @@
+extern crate graphics;
+extern crate opengl_graphics;
+extern crate image;
+extern crate piston;
+extern crate sdl2_window;
+
+use std::path::Path;
+use opengl_graphics::{ GlGraphics, Texture };
+use piston::event_loop::*;
+use piston::input::*;
+use piston::window::WindowSettings;
+use sdl2_window::{ Sdl2Window, OpenGL };
+use graphics::draw_state::BlendPreset;
+
+fn main() {
+    println!("Set image `default-features = true` in Cargo.toml to test");
+    println!("Press A to change blending");
+    println!("Press S to change clip inside/out");
+
+    let opengl = OpenGL::V3_2;
+    let (w, h) = (640, 480);
+    let window: Sdl2Window =
+        WindowSettings::new("glium_graphics: image_test", [w, h])
+        .exit_on_esc(true).build().unwrap();
+
+    let mut blend = BlendPreset::Alpha;
+    let mut clip_inside = true;
+    let rust_logo = Texture::from_path(&Path::new("./assets/rust.png")).unwrap();
+    let mut gl = GlGraphics::new(opengl);
+    for e in window.events() {
+        if let Some(args) = e.render_args() {
+            use graphics::*;
+
+            gl.draw(args.viewport(), |c, g| {
+                clear([0.8, 0.8, 0.8, 1.0], g);
+                g.clear_stencil(0);
+                Rectangle::new([1.0, 0.0, 0.0, 1.0])
+                    .draw([0.0, 0.0, 100.0, 100.0], &c.draw_state, c.transform, g);
+
+                let draw_state = c.draw_state.blend(blend);
+                Rectangle::new([0.5, 1.0, 0.0, 0.3])
+                    .draw([50.0, 50.0, 100.0, 100.0], &draw_state, c.transform, g);
+
+                let transform = c.transform.trans(100.0, 100.0);
+                // Compute clip rectangle from upper left corner.
+                let (clip_x, clip_y, clip_w, clip_h) = (100, 100, 100, 100);
+                let (clip_x, clip_y, clip_w, clip_h) =
+                    (clip_x, c.viewport.unwrap().draw_size[1] as u16 - clip_y - clip_h, clip_w, clip_h);
+                let clipped = c.draw_state.scissor(clip_x, clip_y, clip_w, clip_h);
+                Image::new().draw(&rust_logo, &clipped, transform, g);
+
+                let transform = c.transform.trans(200.0, 200.0);
+                Ellipse::new([1.0, 0.0, 0.0, 1.0])
+                    .draw([0.0, 0.0, 50.0, 50.0], clip_draw_state(), transform, g);
+                Image::new().draw(&rust_logo,
+                    if clip_inside { inside_draw_state() }
+                    else { outside_draw_state() },
+                    transform, g);
+            });
+        }
+
+        if let Some(Button::Keyboard(Key::A)) = e.press_args() {
+            blend = match blend {
+                BlendPreset::Alpha => BlendPreset::Add,
+                BlendPreset::Add => BlendPreset::Multiply,
+                BlendPreset::Multiply => BlendPreset::Invert,
+                BlendPreset::Invert => BlendPreset::Alpha,
+            };
+            println!("Changed blending to {:?}", blend);
+        }
+
+        if let Some(Button::Keyboard(Key::S)) = e.press_args() {
+            clip_inside = !clip_inside;
+            if clip_inside {
+                println!("Changed to clip inside");
+            } else {
+                println!("Changed to clip outside");
+            }
+        }
+    }
+}

--- a/examples/image_test.rs
+++ b/examples/image_test.rs
@@ -11,8 +11,9 @@ use opengl_graphics::*;
 use sdl2_window::Sdl2Window;
 
 fn main() {
+    println!("Set image `default-features = true` in Cargo.toml to test");
     let opengl = OpenGL::V3_2;
-    let window: Sdl2Window = 
+    let window: Sdl2Window =
         WindowSettings::new(
             "opengl_graphics: image_test",
             [300, 300]

--- a/src/back_end.rs
+++ b/src/back_end.rs
@@ -13,6 +13,7 @@ use gl::types::{
 };
 
 // Local crate.
+use draw_state;
 use Texture;
 use shader_utils::{
     compile_shader,
@@ -313,7 +314,7 @@ impl Graphics for GlGraphics {
 
     fn tri_list<F>(
         &mut self,
-        _draw_state: &DrawState,
+        draw_state: &DrawState,
         color: &[f32; 4],
         mut f: F
     )
@@ -325,6 +326,15 @@ impl Graphics for GlGraphics {
             self.use_program(shader_program);
         }
         let ref mut shader = self.colored;
+
+        draw_state::bind_scissor(draw_state.scissor);
+        draw_state::bind_primitive(draw_state.primitive);
+        draw_state::bind_multi_sample(draw_state.multi_sample);
+        draw_state::bind_depth(draw_state.depth);
+        draw_state::bind_stencil(draw_state.stencil,
+            draw_state.primitive.get_cull_face());
+        draw_state::bind_blend(draw_state.blend);
+        draw_state::bind_color_mask(draw_state.color_mask);
 
         unsafe {
             gl::BindVertexArray(shader.vao);
@@ -352,7 +362,7 @@ impl Graphics for GlGraphics {
 
     fn tri_list_uv<F>(
         &mut self,
-        _draw_state: &DrawState,
+        draw_state: &DrawState,
         color: &[f32; 4],
         texture: &Texture,
         mut f: F
@@ -365,6 +375,15 @@ impl Graphics for GlGraphics {
             self.use_program(shader_program);
         }
         let ref mut shader = self.textured;
+
+        draw_state::bind_scissor(draw_state.scissor);
+        draw_state::bind_primitive(draw_state.primitive);
+        draw_state::bind_multi_sample(draw_state.multi_sample);
+        draw_state::bind_depth(draw_state.depth);
+        draw_state::bind_stencil(draw_state.stencil,
+            draw_state.primitive.get_cull_face());
+        draw_state::bind_blend(draw_state.blend);
+        draw_state::bind_color_mask(draw_state.color_mask);
 
         let texture = texture.get_id();
         unsafe {

--- a/src/draw_state.rs
+++ b/src/draw_state.rs
@@ -16,7 +16,7 @@ pub fn bind_state(old_state: &DrawState, new_state: &DrawState) {
         bind_multi_sample(new_state.multi_sample);
     }
     if old_state.scissor != new_state.scissor {
-        bind_scissor(old_state.scissor);
+        bind_scissor(new_state.scissor);
     }
     if old_state.depth != new_state.depth
     || old_state.stencil != new_state.stencil

--- a/src/draw_state.rs
+++ b/src/draw_state.rs
@@ -1,0 +1,216 @@
+/*
+Use same binding of draw state as Gfx.
+Source: https://github.com/gfx-rs/gfx_device_gl/blob/master/src/state.rs
+*/
+
+use gl;
+use graphics::draw_state::target::Rect;
+use graphics::draw_state::state::*;
+use graphics::DrawState;
+
+pub fn bind_state(old_state: &DrawState, new_state: &DrawState) {
+    if old_state.primitive != new_state.primitive {
+        bind_primitive(new_state.primitive);
+    }
+    if old_state.multi_sample != new_state.multi_sample {
+        bind_multi_sample(new_state.multi_sample);
+    }
+    if old_state.scissor != new_state.scissor {
+        bind_scissor(old_state.scissor);
+    }
+    if old_state.depth != new_state.depth
+    || old_state.stencil != new_state.stencil
+    || old_state.primitive.get_cull_face() !=
+        new_state.primitive.get_cull_face() {
+        bind_depth(new_state.depth);
+        bind_stencil(new_state.stencil, new_state.primitive.get_cull_face());
+    }
+    if old_state.blend != new_state.blend {
+        bind_blend(new_state.blend);
+    }
+    if old_state.color_mask != new_state.color_mask {
+        bind_color_mask(new_state.color_mask);
+    }
+}
+
+pub fn bind_primitive(p: Primitive) {
+    unsafe { gl::FrontFace(match p.front_face {
+        FrontFace::Clockwise => gl::CW,
+        FrontFace::CounterClockwise => gl::CCW,
+    }) };
+
+    let (gl_draw, gl_offset) = match p.method {
+        RasterMethod::Point => (gl::POINT, gl::POLYGON_OFFSET_POINT),
+        RasterMethod::Line(width) => {
+            unsafe { gl::LineWidth(width) };
+            (gl::LINE, gl::POLYGON_OFFSET_LINE)
+        },
+        RasterMethod::Fill(cull) => {
+            match cull {
+                CullFace::Nothing => unsafe { gl::Disable(gl::CULL_FACE) },
+                CullFace::Front => { unsafe {
+                    gl::Enable(gl::CULL_FACE);
+                    gl::CullFace(gl::FRONT);
+                }},
+                CullFace::Back => { unsafe {
+                    gl::Enable(gl::CULL_FACE);
+                    gl::CullFace(gl::BACK);
+                }},
+            }
+            (gl::FILL, gl::POLYGON_OFFSET_FILL)
+        },
+    };
+
+    unsafe { gl::PolygonMode(gl::FRONT_AND_BACK, gl_draw) };
+
+    match p.offset {
+        Some(Offset(factor, units)) => unsafe {
+            gl::Enable(gl_offset);
+            gl::PolygonOffset(factor, units as gl::types::GLfloat);
+        },
+        None => unsafe {
+            gl::Disable(gl_offset)
+        },
+    }
+}
+
+pub fn bind_multi_sample(ms: Option<MultiSample>) {
+    match ms {
+        Some(_) => unsafe { gl::Enable(gl::MULTISAMPLE) },
+        None => unsafe { gl::Disable(gl::MULTISAMPLE) },
+    }
+}
+
+pub fn bind_scissor(rect: Option<Rect>) {
+    match rect {
+        Some(r) => { unsafe {
+            gl::Enable(gl::SCISSOR_TEST);
+            gl::Scissor(
+                r.x as gl::types::GLint,
+                r.y as gl::types::GLint,
+                r.w as gl::types::GLint,
+                r.h as gl::types::GLint
+            );
+        }},
+        None => unsafe { gl::Disable(gl::SCISSOR_TEST) },
+    }
+}
+
+fn map_comparison(cmp: Comparison) -> gl::types::GLenum {
+    match cmp {
+        Comparison::Never        => gl::NEVER,
+        Comparison::Less         => gl::LESS,
+        Comparison::LessEqual    => gl::LEQUAL,
+        Comparison::Equal        => gl::EQUAL,
+        Comparison::GreaterEqual => gl::GEQUAL,
+        Comparison::Greater      => gl::GREATER,
+        Comparison::NotEqual     => gl::NOTEQUAL,
+        Comparison::Always       => gl::ALWAYS,
+    }
+}
+
+pub fn bind_depth(depth: Option<Depth>) {
+    match depth {
+        Some(d) => { unsafe {
+            gl::Enable(gl::DEPTH_TEST);
+            gl::DepthFunc(map_comparison(d.fun));
+            gl::DepthMask(if d.write {gl::TRUE} else {gl::FALSE});
+        }},
+        None => unsafe { gl::Disable(gl::DEPTH_TEST) },
+    }
+}
+
+fn map_operation(op: StencilOp) -> gl::types::GLenum {
+    match op {
+        StencilOp::Keep          => gl::KEEP,
+        StencilOp::Zero          => gl::ZERO,
+        StencilOp::Replace       => gl::REPLACE,
+        StencilOp::IncrementClamp=> gl::INCR,
+        StencilOp::IncrementWrap => gl::INCR_WRAP,
+        StencilOp::DecrementClamp=> gl::DECR,
+        StencilOp::DecrementWrap => gl::DECR_WRAP,
+        StencilOp::Invert        => gl::INVERT,
+    }
+}
+
+pub fn bind_stencil(stencil: Option<Stencil>, cull: CullFace) {
+    fn bind_side(face: gl::types::GLenum, side: StencilSide) { unsafe {
+        gl::StencilFuncSeparate(face, map_comparison(side.fun),
+            side.value as gl::types::GLint, side.mask_read as gl::types::GLuint);
+        gl::StencilMaskSeparate(face, side.mask_write as gl::types::GLuint);
+        gl::StencilOpSeparate(face, map_operation(side.op_fail),
+            map_operation(side.op_depth_fail), map_operation(side.op_pass));
+    }}
+    match stencil {
+        Some(s) => {
+            unsafe { gl::Enable(gl::STENCIL_TEST) };
+            if cull != CullFace::Front {
+                bind_side(gl::FRONT, s.front);
+            }
+            if cull != CullFace::Back {
+                bind_side(gl::BACK, s.back);
+            }
+        }
+        None => unsafe { gl::Disable(gl::STENCIL_TEST) },
+    }
+}
+
+fn map_equation(eq: Equation) -> gl::types::GLenum {
+    match eq {
+        Equation::Add    => gl::FUNC_ADD,
+        Equation::Sub    => gl::FUNC_SUBTRACT,
+        Equation::RevSub => gl::FUNC_REVERSE_SUBTRACT,
+        Equation::Min    => gl::MIN,
+        Equation::Max    => gl::MAX,
+    }
+}
+
+fn map_factor(factor: Factor) -> gl::types::GLenum {
+    match factor {
+        Factor::Zero                              => gl::ZERO,
+        Factor::One                               => gl::ONE,
+        Factor::ZeroPlus(BlendValue::SourceColor) => gl::SRC_COLOR,
+        Factor::OneMinus(BlendValue::SourceColor) => gl::ONE_MINUS_SRC_COLOR,
+        Factor::ZeroPlus(BlendValue::SourceAlpha) => gl::SRC_ALPHA,
+        Factor::OneMinus(BlendValue::SourceAlpha) => gl::ONE_MINUS_SRC_ALPHA,
+        Factor::ZeroPlus(BlendValue::DestColor)   => gl::DST_COLOR,
+        Factor::OneMinus(BlendValue::DestColor)   => gl::ONE_MINUS_DST_COLOR,
+        Factor::ZeroPlus(BlendValue::DestAlpha)   => gl::DST_ALPHA,
+        Factor::OneMinus(BlendValue::DestAlpha)   => gl::ONE_MINUS_DST_ALPHA,
+        Factor::ZeroPlus(BlendValue::ConstColor)  => gl::CONSTANT_COLOR,
+        Factor::OneMinus(BlendValue::ConstColor)  => gl::ONE_MINUS_CONSTANT_COLOR,
+        Factor::ZeroPlus(BlendValue::ConstAlpha)  => gl::CONSTANT_ALPHA,
+        Factor::OneMinus(BlendValue::ConstAlpha)  => gl::ONE_MINUS_CONSTANT_ALPHA,
+        Factor::SourceAlphaSaturated => gl::SRC_ALPHA_SATURATE,
+    }
+}
+
+pub fn bind_blend(blend: Option<Blend>) {
+    match blend {
+        Some(b) => { unsafe {
+            gl::Enable(gl::BLEND);
+            gl::BlendEquationSeparate(
+                map_equation(b.color.equation),
+                map_equation(b.alpha.equation)
+            );
+            gl::BlendFuncSeparate(
+                map_factor(b.color.source),
+                map_factor(b.color.destination),
+                map_factor(b.alpha.source),
+                map_factor(b.alpha.destination)
+            );
+            let c = b.value;
+            gl::BlendColor(c[0], c[1], c[2], c[3]);
+        }},
+        None => unsafe { gl::Disable(gl::BLEND) },
+    }
+}
+
+pub fn bind_color_mask(mask: ColorMask) {
+    unsafe { gl::ColorMask(
+        if (mask & RED  ).is_empty() {gl::FALSE} else {gl::TRUE},
+        if (mask & GREEN).is_empty() {gl::FALSE} else {gl::TRUE},
+        if (mask & BLUE ).is_empty() {gl::FALSE} else {gl::TRUE},
+        if (mask & ALPHA).is_empty() {gl::FALSE} else {gl::TRUE}
+    )};
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,3 +23,4 @@ pub mod error;
 
 mod back_end;
 mod texture;
+mod draw_state;


### PR DESCRIPTION
See https://github.com/PistonDevelopers/opengl_graphics/issues/154

- Detect changes from previous draw state
- Added a `draw_state` module for reuse
- Added `GlGraphics::use_draw_state`
- Added `GlGraphics::clear_draw_state`
- Added "draw_state" example for testing
- Added notice about setting `default-features = true` in Cargo.toml to test