### PR TITLE
Fix possible dangling pointer to shader source

### DIFF
--- a/src/shader_utils.rs
+++ b/src/shader_utils.rs
@@ -126,11 +126,13 @@ pub fn compile_shader(
 ) -> Result<GLuint, String> {
     unsafe {
         let shader = gl::CreateShader(shader_type);
-        gl::ShaderSource(shader, 1,
-            &match CString::new(source) {
-                Ok(x) => x.as_ptr(),
+        {
+            let source = &match CString::new(source) {
+                Ok(x) => x,
                 Err(err) => return Err(format!("compile_shader: {}", err))
-            }, ptr::null());
+            };
+            gl::ShaderSource(shader, 1, &source.as_ptr(), ptr::null());
+        }
         gl::CompileShader(shader);
         let mut status = gl::FALSE as GLint;
         gl::GetShaderiv(shader, gl::COMPILE_STATUS, &mut status);


### PR DESCRIPTION
Force the constructed shader source to be dropped only after the
call to gl::ShaderSource.

On Windows x86_64 systems, compiling the shader results in OpenGL
returning syntax errors. The character on which it errors changes
between runs, and includes undefined characters, indicating the
source is invalid. This is a result of the string being dropped
before being copied to the shader object.

Fixes #223 and PistonDevelopers/piston#1032