### PR TITLE
Fix bug causing text to be drawn 2 pixels off

### DIFF
--- a/src/glyph_cache.rs
+++ b/src/glyph_cache.rs
@@ -135,7 +135,7 @@ impl<'b> CharacterCache for GlyphCache<'b> {
 
                 let &mut (offset, size, ref texture) = v.insert((
                     [
-                        bounding_box.min.x as Scalar + 1.0,
+                        bounding_box.min.x as Scalar - 1.0,
                         -pixel_bounding_box.min.y as Scalar + 1.0,
                     ],
                     [


### PR DESCRIPTION
It appears that 4ae01a95d0e958461551104fe709d69f582c0500 introduced a bug causing text to be drawn 2 pixels to the right of where it should be.