### PR TITLE
Added TextureSettings to GlyphCache

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -18,7 +18,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut glyphs = GlyphCache::new("assets/FiraSans-Regular.ttf").unwrap();
+    let mut glyphs = GlyphCache::new("assets/FiraSans-Regular.ttf", TextureSettings::new()).unwrap();
     let mut gl = GlGraphics::new(opengl);
     let mut events = Events::new(EventSettings::new());
     while let Some(e) = events.next(&mut window) {

--- a/examples/text_test.rs
+++ b/examples/text_test.rs
@@ -22,7 +22,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut glyph_cache = GlyphCache::new("assets/FiraSans-Regular.ttf").unwrap();
+    let mut glyph_cache = GlyphCache::new("assets/FiraSans-Regular.ttf", TextureSettings::new()).unwrap();
 
     let mut gl = GlGraphics::new(opengl);
     let mut events = Events::new(EventSettings::new().lazy(true));


### PR DESCRIPTION
This PR changes `GlyphCache` to take a `TextureSettings` parameter in the constructor, which is used for creating the cached `Texture`.

This is useful as it allows you to specify how you want the font to be rendered - for example, a pixel art game may want the fonts to use `Filter::Nearest` for scaling.