### PR TITLE
Use version given in opengl variable when creating window

### DIFF
--- a/examples/draw_state.rs
+++ b/examples/draw_state.rs
@@ -20,6 +20,7 @@ fn main() {
     let (w, h) = (640, 480);
     let mut window: Sdl2Window = WindowSettings::new("opengl_graphics: draw_state", [w, h])
         .exit_on_esc(true)
+        .opengl(opengl)
         .build()
         .unwrap();
 


### PR DESCRIPTION
This is the only example in the folder which does not use the opengl version given above to create the window.