### PR TITLE
Published 0.47.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-opengl_graphics"
-version = "0.46.0"
+version = "0.47.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -27,18 +27,20 @@ name = "opengl_graphics"
 path = "src/lib.rs"
 
 [dependencies]
-image = "0.15.0"
-rusttype = "0.2.0"
+image = "0.16.0"
 gl = "0.6.0"
 piston-shaders_graphics2d = "0.3.1"
 piston-texture = "0.5.0"
-piston2d-graphics = "0.21.0"
-shader_version = "0.2.0"
+shader_version = "0.3.0"
 fnv = "1.0.2"
 
+[dependencies.piston2d-graphics]
+version = "0.22.0"
+features = ["glyph_cache_rusttype"]
+
 [dev-dependencies]
-piston = "0.32.0"
-pistoncore-sdl2_window = "0.43.0"
+piston = "0.34.0"
+pistoncore-sdl2_window = "0.45.0"
 rand = "0.3.15"
 
 [build-dependencies]

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -7,7 +7,7 @@ use piston::event_loop::*;
 use piston::input::*;
 use piston::window::WindowSettings;
 use opengl_graphics::*;
-use opengl_graphics::glyph_cache::GlyphCache;
+use opengl_graphics::GlyphCache;
 use sdl2_window::Sdl2Window;
 
 fn main() {
@@ -18,7 +18,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut glyphs = GlyphCache::new("assets/FiraSans-Regular.ttf", TextureSettings::new()).unwrap();
+    let mut glyphs = GlyphCache::new("assets/FiraSans-Regular.ttf", (), TextureSettings::new()).unwrap();
     let mut gl = GlGraphics::new(opengl);
     let mut events = Events::new(EventSettings::new());
     while let Some(e) = events.next(&mut window) {
@@ -30,7 +30,7 @@ fn main() {
 
                 clear([0.0, 0.0, 0.0, 1.0], g);
                 text::Text::new_color([0.0, 1.0, 0.0, 1.0], 32)
-                    .draw("Hello world!", &mut glyphs, &c.draw_state, transform, g);
+                    .draw("Hello world!", &mut glyphs, &c.draw_state, transform, g).unwrap();
             });
         }
     }

--- a/examples/text_test.rs
+++ b/examples/text_test.rs
@@ -7,7 +7,7 @@ use piston::window::{WindowSettings, Size};
 use piston::event_loop::*;
 use piston::input::*;
 use opengl_graphics::*;
-use opengl_graphics::glyph_cache::GlyphCache;
+use opengl_graphics::GlyphCache;
 use sdl2_window::Sdl2Window;
 
 fn main() {
@@ -22,7 +22,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut glyph_cache = GlyphCache::new("assets/FiraSans-Regular.ttf", TextureSettings::new()).unwrap();
+    let mut glyph_cache = GlyphCache::new("assets/FiraSans-Regular.ttf", (), TextureSettings::new()).unwrap();
 
     let mut gl = GlGraphics::new(opengl);
     let mut events = Events::new(EventSettings::new().lazy(true));
@@ -37,7 +37,7 @@ fn main() {
                                                                      &DrawState::default(),
                                                                      c.transform
                                                                          .trans(10.0, 100.0),
-                                                                     g);
+                                                                     g).unwrap();
             });
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ extern crate shaders_graphics2d as shaders;
 extern crate image;
 extern crate gl;
 extern crate graphics;
-extern crate rusttype;
 extern crate texture as texture_lib;
 
 pub use shader_version::{OpenGL, Shaders};
@@ -18,9 +17,11 @@ pub use texture::Texture;
 pub use texture_lib::*;
 
 pub mod shader_utils;
-pub mod glyph_cache;
 pub mod error;
 pub mod shader_uniforms;
+
+/// Glyph cache implementation for OpenGL backend.
+pub type GlyphCache<'a> = graphics::glyph_cache::rusttype::GlyphCache<'a, (), Texture>;
 
 mod back_end;
 mod texture;


### PR DESCRIPTION
- Updated dependencies
- Use Piston-Graphics’s generic glyph cache

To update code, import `opengl_graphics::GlyphCache` instead of
`opengl_graphics::glyph_cache::GlyphCache`.

The generic glyph cache requires a texture factory parameter. Since
opengl_graphics does not use any factory, pass an empty tuple `()` as
second parameter to `GlyphCache::new`.