### PR TITLE
Upgrade khronos_api 0.0.8 -> 2.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,4 @@ pistoncore-sdl2_window = "0.47.0"
 rand = "0.3.15"
 
 [build-dependencies]
-khronos_api = "0.0.8"
+khronos_api = "2.1.0"


### PR DESCRIPTION
For compatibility with surrounding crate ecosystem.
(It affects the public API of this crate.)