### PR TITLE
bump versions to be compatible with piston2d-graphics v0.45.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-opengl_graphics"
-version = "0.85.1"
+version = "0.86.0"
 edition = "2018"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
@@ -34,39 +34,39 @@ webgl = ["gl"]
 glow = ["piston2d-glow_wrap"]
 
 [dependencies]
-image = "0.25.1"
+image = "0.25.2"
 
 piston-shaders_graphics2d = "0.4.0"
 piston-texture = "0.9.0"
-piston-viewport = "1.0.0"
+piston-viewport = "1.0.2"
 shader_version = "0.7.0"
-fnv = "1.0.2"
+fnv = "1.0.7"
 
 piston2d-glow_wrap = { path = "glow_wrap", version = "0.1.0", optional = true}
-gl = { version = "0.13.0", optional = true}
+gl = { version = "0.14.0", optional = true}
 
 
 [dependencies.piston2d-graphics]
-version = "0.44.0"
+version = "0.45.0"
 features = ["glyph_cache_rusttype"]
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dev-dependencies]
-piston = {version = "0.55.0", features = ["async"]}
+piston = {version = "1.0.0", features = ["async"]}
 pistoncore-sdl2_window = "0.69.0"
-rand = "0.6.0"
-tokio = {version = "1.34.0", features = ["full"]}
-futures = "0.3.29"
-glutin = "0.28.0"
-glow = "0.12.0"
+rand = "0.8.5"
+tokio = {version = "1.40.0", features = ["full"]}
+futures = "0.3.31"
+glutin = "0.32.1"
+glow = "0.14.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-glow = "0.12.0"
-web-sys = { version = "0.3.0", features = [
+glow = "0.14.2"
+web-sys = { version = "0.3.72", features = [
   "HtmlCanvasElement",
   "WebGl2RenderingContext",
   "Window",
 ] }
-wasm-bindgen = { version = "0.2.0" }
+wasm-bindgen = { version = "0.2.95" }
 
 [build-dependencies]
-khronos_api = "2.1.0"
+khronos_api = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ features = ["glyph_cache_rusttype"]
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dev-dependencies]
 piston = {version = "1.0.0", features = ["async"]}
-pistoncore-sdl2_window = "0.69.0"
+pistoncore-sdl2_window = "0.70.0"
 rand = "0.8.5"
 tokio = {version = "1.40.0", features = ["full"]}
 futures = "0.3.31"


### PR DESCRIPTION
also updates other dependencies. everything seems to work if 
https://github.com/PistonDevelopers/sdl2_window/pull/278 is used.